### PR TITLE
Fixed a crash when using upgrade planner on an adjacent belt.

### DIFF
--- a/objects/balancer.lua
+++ b/objects/balancer.lua
@@ -195,7 +195,7 @@ function balancer_functions.run(balancer_index)
 
             for k, lane_index in pairs(current_lanes) do
                 local lane = global.lanes[lane_index]
-                if #lane > 0 then
+                if lane ~= nil and lane.valid and #lane > 0 then
                     -- remove item from lane and add to buffer
                     local lua_item = lane[1]
                     local simple_item = convert_LuaItemStack_to_SimpleItemStack(lua_item)


### PR DESCRIPTION
Sometimes the lane object can be in an invalid state and attempting to access #lane (or lane.__len) will crash the game. Note I was using the Construction Drones mod to do the replacing, rather than vanilla bots, but in general this seems like it should be checked for valid state anyway. Easily replicated bug, this fixed it.